### PR TITLE
changed version of artifact 3.4.0 -> 3.4.1

### DIFF
--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -31,7 +31,7 @@ of your build descriptor:
 <dependency>
     <groupId>io.vertx</groupId>
     <artifactId>vertx-mqtt-server</artifactId>
-    <version>3.4.0-SNAPSHOT</version>
+    <version>3.4.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -44,7 +44,7 @@ maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-mqtt-server:3.4.0-SNAPSHOT
+compile io.vertx:vertx-mqtt-server:3.4.1-SNAPSHOT
 ----
 
 == Getting Started

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -31,7 +31,7 @@ of your build descriptor:
 <dependency>
     <groupId>io.vertx</groupId>
     <artifactId>vertx-mqtt-server</artifactId>
-    <version>3.4.0-SNAPSHOT</version>
+    <version>3.4.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -44,7 +44,7 @@ maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-mqtt-server:3.4.0-SNAPSHOT
+compile io.vertx:vertx-mqtt-server:3.4.1-SNAPSHOT
 ----
 
 == Getting Started

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -31,7 +31,7 @@ of your build descriptor:
 <dependency>
     <groupId>io.vertx</groupId>
     <artifactId>vertx-mqtt-server</artifactId>
-    <version>3.4.0-SNAPSHOT</version>
+    <version>3.4.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -44,7 +44,7 @@ maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-mqtt-server:3.4.0-SNAPSHOT
+compile io.vertx:vertx-mqtt-server:3.4.1-SNAPSHOT
 ----
 
 == Getting Started

--- a/src/main/asciidoc/kotlin/index.adoc
+++ b/src/main/asciidoc/kotlin/index.adoc
@@ -31,7 +31,7 @@ of your build descriptor:
 <dependency>
     <groupId>io.vertx</groupId>
     <artifactId>vertx-mqtt-server</artifactId>
-    <version>3.4.0-SNAPSHOT</version>
+    <version>3.4.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -44,7 +44,7 @@ maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-mqtt-server:3.4.0-SNAPSHOT
+compile io.vertx:vertx-mqtt-server:3.4.1-SNAPSHOT
 ----
 
 == Getting Started

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -31,7 +31,7 @@ of your build descriptor:
 <dependency>
     <groupId>io.vertx</groupId>
     <artifactId>vertx-mqtt-server</artifactId>
-    <version>3.4.0-SNAPSHOT</version>
+    <version>3.4.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -44,7 +44,7 @@ maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-mqtt-server:3.4.0-SNAPSHOT
+compile io.vertx:vertx-mqtt-server:3.4.1-SNAPSHOT
 ----
 
 == Getting Started


### PR DESCRIPTION
The problem is that maven can't find 3.4.0 version of artifact in the repository (https://oss.sonatype.org/content/repositories/snapshots). I have fixed it changing the version to 3.4.1 .