### PR TITLE
Make `vertx-mqtt-server` an OSGi bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,61 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <archive>
+                <!-- A manifest containing the OSGi metadata has been generated using the maven-bundle-plugin -->
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+              </archive>
+              <!-- Remove examples and docoverride -->
+              <excludes>
+                <exclude>/examples/**</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <version>3.2.0</version>
+
+        <executions>
+          <execution>
+            <id>default-bnd-process</id>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <bnd><![CDATA[
+          Import-Package: \
+            groovy.lang.*;resolution:=optional,\
+            org.codehaus.groovy.*;resolution:=optional,\
+            kotlin.*;resolution:=optional,\
+            io.vertx.groovy.*;resolution:=optional,\
+            io.vertx.ext.auth,\
+            io.vertx.ext.auth.*;resolution:=optional,\
+            io.vertx.lang.rxjava.*;resolution:=optional,\
+            io.vertx.lang.groovy.*;resolution:=optional,\
+            io.vertx.codegen.annotations;resolution:=optional,\
+            io.vertx.rx.java;resolution:=optional,\
+            io.vertx.rxjava.core.*;resolution:=optional,\
+            io.vertx.rxjava.ext.auth.*;resolution:=optional,\
+            rx.*;resolution:=optional,\
+            *
+          -exportcontents: !*impl, !examples, *
+          ]]></bnd>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 
 </project>


### PR DESCRIPTION
All package dependencies for generated classes (groovy, rx, …) are marked `optional`.

Fixes #24 

Here is the Bnd `print` output:

```
bnd print target/vertx-mqtt-server-3.5.0-SNAPSHOT.jar
[MANIFEST vertx-mqtt-server-3.5.0-SNAPSHOT]
Archiver-Version                         Plexus Archiver                         
Bnd-LastModified                         1497815568501                           
Build-Jdk                                1.8.0_121                               
Built-By                                 guillaume                               
Bundle-ManifestVersion                   2                                       
Bundle-Name                              Vert.x MQTT server                      
Bundle-SymbolicName                      vertx-mqtt-server                       
Bundle-Version                           3.5.0.201706181952                      
Created-By                               1.8.0_121 (Oracle Corporation)          
Export-Package                           io.vertx.groovy.mqtt;uses:="io.vertx.core,io.vertx.mqtt,org.codehaus.groovy.runtime.m12n";version="3.5.0",io.vertx.kotlin.mqtt;uses:="io.vertx.core.buffer,io.vertx.core.http,io.vertx.core.net,io.vertx.mqtt,kotlin";version="3.5.0",io.vertx.mqtt;uses:="io.netty.handler.codec.mqtt,io.vertx.codegen.annotations,io.vertx.core,io.vertx.core.buffer,io.vertx.core.json,io.vertx.core.net,io.vertx.mqtt.messages";version="3.5.0",io.vertx.mqtt.messages;uses:="io.netty.buffer,io.netty.handler.codec.mqtt,io.vertx.codegen.annotations,io.vertx.core.buffer,io.vertx.mqtt";version="3.5.0",io.vertx.rxjava.mqtt;uses:="io.netty.handler.codec.mqtt,io.vertx.core,io.vertx.lang.rxjava,io.vertx.mqtt,io.vertx.rxjava.core,io.vertx.rxjava.core.buffer,io.vertx.rxjava.mqtt.messages,rx";version="3.5.0",io.vertx.rxjava.mqtt.messages;uses:="io.netty.handler.codec.mqtt,io.vertx.lang.rxjava,io.vertx.mqtt.messages,io.vertx.rxjava.core.buffer,io.vertx.rxjava.mqtt";version="3.5.0",vertx-mqtt-server;version="3.5.0",vertx-mqtt-server-js;version="3.5.0"
Import-Package                           groovy.lang;resolution:=optional;version="[2.4,3)",org.codehaus.groovy.runtime.m12n;resolution:=optional;version="[2.4,3)",kotlin;resolution:=optional,io.vertx.lang.rxjava;resolution:=optional;version="[3.4,4)",io.vertx.codegen.annotations;resolution:=optional;version="[3.4,4)",io.vertx.rx.java;resolution:=optional;version="[3.4,4)",io.vertx.rxjava.core;resolution:=optional;version="[3.4,4)",io.vertx.rxjava.core.buffer;resolution:=optional;version="[3.4,4)",rx;resolution:=optional;version="[1.3,2)",io.netty.buffer;version="[4.1,5)",io.netty.channel;version="[4.1,5)",io.netty.handler.codec;version="[4.1,5)",io.netty.handler.codec.mqtt;version="[4.1,5)",io.netty.handler.logging;version="[4.1,5)",io.netty.handler.timeout;version="[4.1,5)",io.vertx.core;version="[3.4,4)",io.vertx.core.buffer;version="[3.4,4)",io.vertx.core.http;version="[3.4,4)",io.vertx.core.impl;version="[3.4,4)",io.vertx.core.json;version="[3.4,4)",io.vertx.core.net;version="[3.4,4)",io.vertx.core.net.impl;version="[3.4,4)",io.vertx.core.spi.metrics;version="[3.4,4)",io.vertx.rxjava.mqtt,io.vertx.rxjava.mqtt.messages,io.vertx.ext.auth
Manifest-Version                         1.0                                     
Maven-Artifact-Id                        vertx-mqtt-server                       
Maven-Group-Id                           io.vertx                                
Maven-Version                            3.5.0-SNAPSHOT                          
Private-Package                          examples,io.vertx.mqtt.impl,io.vertx.mqtt.messages.impl
Require-Capability                       osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
Tool                                     Bnd-3.2.0.201605172007                  

[IMPEXP]
Import-Package
  groovy.lang                            {resolution:=optional, version=[2.4,3)}
  io.netty.buffer                        {version=[4.1,5)}
  io.netty.channel                       {version=[4.1,5)}
  io.netty.handler.codec                 {version=[4.1,5)}
  io.netty.handler.codec.mqtt            {version=[4.1,5)}
  io.netty.handler.logging               {version=[4.1,5)}
  io.netty.handler.timeout               {version=[4.1,5)}
  io.vertx.codegen.annotations           {resolution:=optional, version=[3.4,4)}
  io.vertx.core                          {version=[3.4,4)}
  io.vertx.core.buffer                   {version=[3.4,4)}
  io.vertx.core.http                     {version=[3.4,4)}
  io.vertx.core.impl                     {version=[3.4,4)}
  io.vertx.core.json                     {version=[3.4,4)}
  io.vertx.core.net                      {version=[3.4,4)}
  io.vertx.core.net.impl                 {version=[3.4,4)}
  io.vertx.core.spi.metrics              {version=[3.4,4)}
  io.vertx.ext.auth                      
  io.vertx.lang.rxjava                   {resolution:=optional, version=[3.4,4)}
  io.vertx.rx.java                       {resolution:=optional, version=[3.4,4)}
  io.vertx.rxjava.core                   {resolution:=optional, version=[3.4,4)}
  io.vertx.rxjava.core.buffer            {resolution:=optional, version=[3.4,4)}
  io.vertx.rxjava.mqtt                   
  io.vertx.rxjava.mqtt.messages          
  kotlin                                 {resolution:=optional}
  org.codehaus.groovy.runtime.m12n       {resolution:=optional, version=[2.4,3)}
  rx                                     {resolution:=optional, version=[1.3,2)}
Export-Package
  io.vertx.groovy.mqtt                   {version=3.5.0}
  io.vertx.kotlin.mqtt                   {version=3.5.0}
  io.vertx.mqtt                          {version=3.5.0}
  io.vertx.mqtt.messages                 {version=3.5.0}
  io.vertx.rxjava.mqtt                   {version=3.5.0}
  io.vertx.rxjava.mqtt.messages          {version=3.5.0}
  vertx-mqtt-server                      {version=3.5.0}
  vertx-mqtt-server-js                   {version=3.5.0}
 ```